### PR TITLE
feat: extract and use implementation year from scraped data

### DIFF
--- a/format/format_units.go
+++ b/format/format_units.go
@@ -183,10 +183,21 @@ func FormatUnit(raw_unit map[string]interface{}) map[string]interface{} {
 
 // raw_unit["level"].(map[string]interface{})["value"],
 // Generates two artefacts, one is IO'd
-func FormatUnits(raw_units []map[string]interface{}) map[string]interface{} {
+// Returns: (formatted_unit_data, detected_year)
+func FormatUnits(raw_units []map[string]interface{}) (map[string]interface{}, string) {
 
 	var formatted_unit_data = make(map[string]interface{})
 	var prohibition_candidates [][]string
+
+	// Extract implementation year from first unit with the field
+	var detectedYear string = "2024" // Default fallback
+	for _, unit := range raw_units {
+		if implYear, ok := unit["implementation_year"].(string); ok && implYear != "" {
+			detectedYear = implYear
+			fmt.Printf("Detected implementation year: %s\n", detectedYear)
+			break
+		}
+	}
 
 	for _, unit := range raw_units {
 		code, ok := unit["code"].(string)
@@ -226,6 +237,6 @@ func FormatUnits(raw_units []map[string]interface{}) map[string]interface{} {
 		fmt.Println("Encountered an error writing:", err)
 	}
 
-	return formatted_unit_data
+	return formatted_unit_data, detectedYear
 
 }

--- a/scrape/requisites.go
+++ b/scrape/requisites.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Processes the requisites
-func RequisiteScrape(unitCodeList [][]string, fileName string) {
+func RequisiteScrape(unitCodeList [][]string, fileName string, year int) {
 	numWorkers := 10
 
 	var wg sync.WaitGroup
@@ -25,7 +25,7 @@ func RequisiteScrape(unitCodeList [][]string, fileName string) {
 		go func(unitCodesSlice [][]string) {
 			defer wg.Done()
 			for _, unitCode := range unitCodesSlice {
-				response, err := postRequest(unitCode)
+				response, err := postRequest(unitCode, year)
 				if err != nil {
 					fmt.Printf("Error for unit %s: %v\n", unitCode, err)
 				} else {
@@ -50,9 +50,9 @@ func RequisiteScrape(unitCodeList [][]string, fileName string) {
 	saveResponsesToJSON(responses, fileName)
 }
 
-func postRequest(unitCodes []string) (map[string]interface{}, error) {
+func postRequest(unitCodes []string, year int) (map[string]interface{}, error) {
 	url := "https://mscv.apps.monash.edu"
-	payload := createRequestPayload(unitCodes)
+	payload := createRequestPayload(unitCodes, year)
 
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
@@ -79,7 +79,7 @@ func postRequest(unitCodes []string) (map[string]interface{}, error) {
 	return response, nil
 }
 
-func createRequestPayload(unitCodes []string) map[string]interface{} {
+func createRequestPayload(unitCodes []string, year int) map[string]interface{} {
 	units := make([]map[string]interface{}, len(unitCodes))
 
 	for i, unitCode := range unitCodes {
@@ -91,13 +91,13 @@ func createRequestPayload(unitCodes []string) map[string]interface{} {
 	}
 
 	payload := map[string]interface{}{
-		"startYear":            2024,
+		"startYear":            year,
 		"advancedStanding":     []interface{}{},
 		"internationalStudent": false,
 		"courseInfo":           map[string]interface{}{},
 		"teachingPeriods": []map[string]interface{}{
 			{
-				"year":         2024,
+				"year":         year,
 				"code":         "S1-01",
 				"units":        units,
 				"intermission": false,


### PR DESCRIPTION
- Modify FormatUnits to detect and return implementation_year from raw units
- Save detected year to data/detected_year.json during format step
- Update RequisiteScrape to accept year parameter
- Load detected year in main.go and pass to MonPlan API requests
- Replace hardcoded 2024 with dynamic year for accurate requisite validation
- Add safety check for empty prohibition containers in format_units.go